### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,17 @@ pull request.
 See [GitHub's official documentation](https://help.github.com/articles/using-pull-requests/)
 for more details.
 
+## When to add content to the handbook
+
+Add content to the SystemLink Operations Handbook in any of the following situations:
+
+- The content is primarily example code. 
+- The content covers more advanced or corner-case scenarios than the [ni.com help](https://www.ni.com/documentation/en/systemlink/latest/manual/manual-overview/).
+- Customers need the content sooner than the current release timeline can deliver it.
+- The content covers a preview feature. If this is the case, remember to add a note saying so.
+
+Otherwise, raise an issue in GitHub or leave feedback on ni.com to request help content.
+
 ## Developer Setup
 
 ### Hosting handbook locally


### PR DESCRIPTION
Adding brief guidelines on what types of content people can contribute to the handbook.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-operations-handbook/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR contains updates that provide guidelines on what types of content people can contribute to the handbook.

### Why should this Pull Request be merged?

This documentation helps clarify the role of the Ops Handbook for internal and external users.

### What testing has been done?

- NA
